### PR TITLE
Integration tests use snapshots to cleanup after themselves

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "ganache-cli": "^6.1.6",
     "husky": "^0.14.3",
     "lint-staged": "^7.2.0",
+    "node-fetch": "^2.2.0",
     "prettier": "^1.13.5",
     "react-styleguidist": "^7.0.20",
     "redux-mock-store": "^1.5.3",

--- a/test/chain/integration.test.js
+++ b/test/chain/integration.test.js
@@ -6,10 +6,26 @@ import {
   breakLink,
   sendMkr
 } from '../../src/chain/write';
-import { useGanache, ganacheAccounts, ganacheCoinbase } from '../helpers';
+import {
+  useGanache,
+  takeSnapshot,
+  restoreSnapshot,
+  ganacheAccounts,
+  ganacheCoinbase
+} from '../helpers';
+
+let snapshotId = null;
 
 beforeAll(() => {
   useGanache();
+});
+
+beforeEach(async () => {
+  snapshotId = await takeSnapshot();
+});
+
+afterEach(async () => {
+  await restoreSnapshot(snapshotId);
 });
 
 const linkAccounts = async (cold, hot) => {

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,8 +1,59 @@
 import { setWeb3Provider } from '../../src/chain/web3';
+import fetch from 'node-fetch';
+
+function ganacheAddress() {
+  const port = process.env.GOV_TESTNET_PORT || 2000;
+  return `http://localhost:${port}`;
+}
 
 export function useGanache() {
-  const port = process.env.GOV_TESTNET_PORT || 2000;
-  setWeb3Provider('http://localhost:' + port);
+  setWeb3Provider(ganacheAddress());
+}
+
+let requestCount = 0;
+
+export async function takeSnapshot() {
+  const id = requestCount;
+  requestCount += 1;
+
+  const res = await fetch(ganacheAddress(), {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'evm_snapshot',
+      params: [],
+      id: id
+    })
+  });
+
+  const json = await res.json();
+  return parseInt(json['result'], 16);
+}
+
+export async function restoreSnapshot(snapId) {
+  const id = requestCount;
+  requestCount += 1;
+
+  const res = await fetch(ganacheAddress(), {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'evm_revert',
+      params: [snapId],
+      id: id
+    })
+  });
+
+  const json = await res.json();
+  return json['result'];
 }
 
 export const fakeAddresses = ['0xbeefed1bedded2dabbed3defaced4decade5dead'];

--- a/yarn.lock
+++ b/yarn.lock
@@ -6466,6 +6466,10 @@ node-fetch@^1.0.1, node-fetch@~1.7.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+node-fetch@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
+
 node-forge@0.7.5:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"


### PR DESCRIPTION
Adds a couple of helpers to make use of the snapshoting features in ganache (see [here](https://github.com/trufflesuite/ganache-cli#implemented-methods)).

Modifies the tests in `integration.test.js` to revert to a clean snapshot after each test.