### PR TITLE
Proxy address from logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@craco/craco": "^3.1.0",
     "@makerdao/dai": "^0.9.8",
-    "@makerdao/dai-plugin-governance": "^0.3.0",
+    "@makerdao/dai-plugin-governance": "^0.3.2",
     "@makerdao/dai-plugin-ledger-web": "^0.9.3",
     "@makerdao/dai-plugin-trezor-web": "^0.9.2",
     "@makerdao/ui-components": "1.0.0-alpha.8",

--- a/src/reducers/proxy.js
+++ b/src/reducers/proxy.js
@@ -185,7 +185,7 @@ export const approveLink = ({ hotAccount }) => (dispatch, getState) => {
     successAction: async () =>
       dispatch({
         type: STORE_PROXY_ADDRESS,
-        payload: (await approveLink).proxyAddress()
+        payload: (await approveLink).proxyAddress
       })
   });
 };
@@ -299,7 +299,6 @@ export const mkrApproveProxy = () => (dispatch, getState) => {
   if (!proxyAddress) {
     //if proxy address not stored in accounts yet, then it should be in proxy store
     proxyAddress = getState().proxy.proxyAddress;
-    console.log('proxyAddress in mkrApproveProxy', proxyAddress);
   }
   const giveProxyAllowance = window.maker
     .getToken(MKR)
@@ -330,7 +329,8 @@ const initialState = {
   coldAddress: '',
   sendMkrAmount: 0,
   withdrawMkrAmount: 0,
-  linkGas: 0
+  linkGas: 0,
+  proxyAddress: ''
 };
 
 // const withExisting = { ...initialState, ...existingState };


### PR DESCRIPTION
This stores the proxy address in the redux store as soon as the approveLink transaction is mined, taking advantage of [this pr for the gov plugin](https://github.com/makerdao/dai-plugin-governance/pull/6).

The proxy address is normally stored in the accounts part of the redux store, but to make things simple I just store this proxy address in the proxy part of the store, and only rely on it if what's in the accounts part is empty, so nothing else needs to be updated.  But this may not be the most elegant solution.

If this looks good, I'll write a test for STORE_PROXY_ADDRESS before merging.