### PR TITLE
Make sure we're using the latest header

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@makerdao/dai-plugin-governance": "^0.3.5",
     "@makerdao/dai-plugin-ledger-web": "^0.9.7",
     "@makerdao/dai-plugin-trezor-web": "^0.9.4",
-    "@makerdao/ui-components": "1.0.0-alpha.8",
+    "@makerdao/ui-components": "1.0.0-alpha.21",
     "bignumber.js": "^8.0.1",
     "ethers": "^4.0.18",
     "jazzicon": "^1.5.0",


### PR DESCRIPTION
This is so we remove the oasis.direct link under the `products` dropdown.
not simply pushing this straight since there has been a number of other changes to this component since, worried about possible regressions.

deployed this change here for 👀https://maker-governance-dashboard-server-iyhdrdxiao.now.sh/